### PR TITLE
Update __init__.py

### DIFF
--- a/icd10/__init__.py
+++ b/icd10/__init__.py
@@ -123,7 +123,7 @@ def find(s: str) -> Optional[ICD10]:
 
 
 def in_chapter(block: str, icd10: str) -> bool:
-    alpha, numeric = ord(icd10[0]), int(icd10[1:3].lstrip('0'))
+    alpha, numeric = ord(icd10[0]), int(icd10[1:3].lstrip('0').strip('ABCDEFGHIJKLMNOPQRSTUVWXYZ') or 0)
     sblock, eblock = block.split('-')  # A00-B99
     salpha, snumeric = ord(sblock[0]), int(sblock[1:].lstrip('0') or 0)
     ealpha, enumeric = ord(eblock[0]), int(eblock[1:].lstrip('0') or 0)


### PR DESCRIPTION
edited line 126 to fix errors with ICD codes generating "ValueError: invalid literal for int() with base 10: ''  such as "Z3A.38" or "R00.0"