### PR TITLE
Fix edge case where code in multiple letter chapter is not found if the numeric part is over the end digit of the chapter.

### DIFF
--- a/icd10/__init__.py
+++ b/icd10/__init__.py
@@ -123,7 +123,7 @@ def find(s: str) -> Optional[ICD10]:
 
 
 def in_chapter(block: str, icd10: str) -> bool:
-    alpha, numeric = ord(icd10[0]), int(icd10[1:3].lstrip('0'))
+    alpha, numeric = ord(icd10[0]), int(icd10[1:3].lstrip('0') or 0)
     sblock, eblock = block.split('-')  # A00-B99
     salpha, snumeric = ord(sblock[0]), int(sblock[1:].lstrip('0') or 0)
     ealpha, enumeric = ord(eblock[0]), int(eblock[1:].lstrip('0') or 0)

--- a/icd10/__init__.py
+++ b/icd10/__init__.py
@@ -130,7 +130,7 @@ def in_chapter(block: str, icd10: str) -> bool:
     if salpha != ealpha:
         enumeric += 100
         
-    if alpha == ealpha:
+    if alpha != salpha and alpha == ealpha:
         numeric += 100
     
     return salpha <= alpha <= ealpha and snumeric <= numeric <= enumeric

--- a/icd10/__init__.py
+++ b/icd10/__init__.py
@@ -127,4 +127,10 @@ def in_chapter(block: str, icd10: str) -> bool:
     sblock, eblock = block.split('-')  # A00-B99
     salpha, snumeric = ord(sblock[0]), int(sblock[1:].lstrip('0') or 0)
     ealpha, enumeric = ord(eblock[0]), int(eblock[1:].lstrip('0') or 0)
+    if salpha != ealpha:
+        enumeric += 100
+        
+    if alpha == ealpha:
+        numeric += 100
+    
     return salpha <= alpha <= ealpha and snumeric <= numeric <= enumeric

--- a/icd10/__version__.py
+++ b/icd10/__version__.py
@@ -2,7 +2,7 @@ __title__ = 'icd10-cm'
 __description__ = ('ICD-10 codes for diseases, signs and symptoms, abnormal findings, '
                    'complaints, social circumstances, and external causes of injury or disease')
 __url__ = 'https://github.com/bryand1/icd10-cm'
-__version__ = '0.0.6'
+__version__ = '0.0.6.1'
 __author__ = 'Bryan Andrade'
 __author_email__ = 'me@bryanandrade.com'
 __license__ = 'MIT'

--- a/icd10/__version__.py
+++ b/icd10/__version__.py
@@ -2,7 +2,7 @@ __title__ = 'icd10-cm'
 __description__ = ('ICD-10 codes for diseases, signs and symptoms, abnormal findings, '
                    'complaints, social circumstances, and external causes of injury or disease')
 __url__ = 'https://github.com/bryand1/icd10-cm'
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 __author__ = 'Bryan Andrade'
 __author_email__ = 'me@bryanandrade.com'
 __license__ = 'MIT'


### PR DESCRIPTION
I.e. if the ICD code is "C85.1", the previous version "in_chapter" function will return false on the "C00-D48" code block even though "C85.1" belong to that code block. This pull request proposes a fix to the issue while preserving the default behaviour for other non-edge cases.